### PR TITLE
Fix issue with basic Kotlin types being converted into Java

### DIFF
--- a/example/src/main/kotlin/com/github/lotuslambda/Foo.kt
+++ b/example/src/main/kotlin/com/github/lotuslambda/Foo.kt
@@ -3,6 +3,5 @@ package com.github.lotuslambda
 import com.lotuslambda.unikons.Union
 
 class Bar
-
-@Union(Bar::class, Double::class)
+@Union(Bar::class, Double::class, String::class)
 class Foo

--- a/example/src/test/kotlin/com/github/lotuslambda/FooTest.kt
+++ b/example/src/test/kotlin/com/github/lotuslambda/FooTest.kt
@@ -8,6 +8,6 @@ class FooTest {
     fun foo() {
         FooUnion.Bar(Bar())
         FooUnion.Double(1.2)
+        FooUnion.String("Test")
     }
-
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 kotlin.code.style=official
 kapt.include.compile.classpath=false
+kapt.use.worker.api=true

--- a/unikons/build.gradle
+++ b/unikons/build.gradle
@@ -10,6 +10,8 @@ targetCompatibility = 1.8
 
 dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    implementation 'me.eugeniomarletti.kotlin.metadata:kotlin-metadata:1.4.0'
+
     implementation  'com.squareup:kotlinpoet:1.4.3'
 }
 

--- a/unikons/src/main/kotlin/com/lotuslambda/unikons/TransformUnion.kt
+++ b/unikons/src/main/kotlin/com/lotuslambda/unikons/TransformUnion.kt
@@ -2,6 +2,7 @@ package com.lotuslambda.unikons
 
 import com.squareup.kotlinpoet.*
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import javax.annotation.processing.ProcessingEnvironment
 import javax.lang.model.element.Element
 import javax.lang.model.type.MirroredTypesException
 import javax.lang.model.type.TypeMirror
@@ -32,78 +33,82 @@ class TransformUnion {
         val union = element.getAnnotation(Union::class.java)
         val unionName = "${element.simpleName}Union"
         val unionClassName = ClassName(packageOf, unionName)
-        val generic = TypeVariableName("UnionedType")
+        val generic = TypeVariableName("UnionizedType")
+
+        //way to access elements of annotation if they're a Class/K<Class>
+
+        val typesInUnion: List<TypeMirror> = try {
+            union.types.map { it as TypeMirror }
+        } catch (e: MirroredTypesException) {
+            e.typeMirrors
+        }
+
         return FileSpec.builder(packageOf, unionName)
             .addType(
-                TypeSpec.classBuilder(unionClassName)
+                TypeSpec
+                    .classBuilder(unionClassName)
                     .addTypeVariable(generic)
                     .primaryConstructor(
                         FunSpec.constructorBuilder()
                             .addParameter(VALUE, generic)
                             .build()
-                    ).addModifiers(KModifier.SEALED)
+                    )
+                    .addModifiers(KModifier.SEALED)
                     .addProperty(
                         PropertySpec.builder(VALUE, generic)
                             .initializer(VALUE)
                             .build()
                     )
                     .apply {
-                        //way to access elements of annotation if they're a Class/K<Class>
-                        val typesInUnion: List<TypeMirror> = try {
-                            union.types.map { it as TypeMirror }
-                        } catch (e: MirroredTypesException) {
-                            e.typeMirrors
-                        }
-
                         //holds creation methods
                         val companionObject = TypeSpec.companionObjectBuilder()
                         //create subclasses for each type
-                        typesInUnion.map { typeMirror ->
-                            val currentClass = ClassName.bestGuess(typeMirror.asTypeName().toString())
-                            val name = currentClass.simpleName
-                            val classForTypeName = "$name$unionName"
-                            val componentMethod = companionMethodBuilderFor(
-                                type = typeMirror.asTypeName(),
-                                typeName = name,
-                                className = classForTypeName,
-                                unionName = unionName
-                            ).build()
-                            val generatedSubclass = subclassBuilderFor(
-                                classForTypeName = classForTypeName,
-                                typeMirror = typeMirror,
-                                unionClassName = unionClassName,
-                                currentClass = currentClass
-                            ).build()
-                            Pair(generatedSubclass, componentMethod)
-                        }.forEach { (typeSpec, funSpec) ->
-                            addType(typeSpec)
-                            companionObject.addFunction(funSpec)
-                        }
+                        typesInUnion
+                            .map { it.toKotlinClassName() }
+                            .map { typeInUnion ->
+                                val name = typeInUnion.simpleName
+                                val nameAsUnionClass = "$name$unionName"
+
+                                val companionMethod = companionMethodBuilderFor(
+                                    type = typeInUnion,
+                                    typeName = name,
+                                    className = nameAsUnionClass,
+                                    unionName = unionName
+                                ).build()
+
+                                val generatedSubclass = subclassBuilderFor(
+                                    classForTypeName = nameAsUnionClass,
+                                    unionClassName = unionClassName,
+                                    currentClass = typeInUnion
+                                ).build()
+
+                                Pair(generatedSubclass, companionMethod)
+                            }.forEach { (typeSpec, companionMethod) ->
+                                addType(typeSpec)
+                                companionObject.addFunction(companionMethod)
+                            }
 
                         addType(companionObject.build())
-                    }.build()
 
+                    }.build()
             ).build()
     }
 
     private fun subclassBuilderFor(
         classForTypeName: String,
-        typeMirror: TypeMirror,
         unionClassName: ClassName,
         currentClass: ClassName
     ): TypeSpec.Builder = TypeSpec.classBuilder(classForTypeName)
-        .addModifiers(KModifier.PRIVATE)
         .primaryConstructor(
             FunSpec.constructorBuilder()
-                .addParameter(VALUE, typeMirror.asTypeName())
+                .addParameter(VALUE, currentClass)
                 .build()
         )
         .superclass(unionClassName.parameterizedBy(currentClass))
-        .addSuperclassConstructorParameter(VALUE, typeMirror)
-
+        .addSuperclassConstructorParameter(VALUE, currentClass)
 
     private fun companionMethodBuilderFor(
-        type: TypeName,
+        type: ClassName,
         typeName: String,
         className: String,
         unionName: String

--- a/unikons/src/main/kotlin/com/lotuslambda/unikons/UnionProcessor.kt
+++ b/unikons/src/main/kotlin/com/lotuslambda/unikons/UnionProcessor.kt
@@ -1,11 +1,10 @@
 package com.lotuslambda.unikons
 
 import com.squareup.kotlinpoet.FileSpec
+import me.eugeniomarletti.kotlin.metadata.KotlinMetadataUtils
+import me.eugeniomarletti.kotlin.processing.KotlinAbstractProcessor
 import java.io.File
-import javax.annotation.processing.AbstractProcessor
-import javax.annotation.processing.RoundEnvironment
-import javax.annotation.processing.SupportedOptions
-import javax.annotation.processing.SupportedSourceVersion
+import javax.annotation.processing.*
 import javax.lang.model.SourceVersion
 import javax.lang.model.element.TypeElement
 import javax.tools.Diagnostic.Kind.ERROR
@@ -14,30 +13,31 @@ private const val KAPT_KOTLIN_GENERATED_OPTION_NAME = "kapt.kotlin.generated"
 
 @SupportedSourceVersion(SourceVersion.RELEASE_8)
 @SupportedOptions(KAPT_KOTLIN_GENERATED_OPTION_NAME)
-class UnionProcessor : AbstractProcessor() {
+class UnionProcessor : KotlinAbstractProcessor() {
+    val transformer = TransformUnion()
 
     override fun getSupportedSourceVersion(): SourceVersion = SourceVersion.latest()
 
     override fun getSupportedAnnotationTypes(): MutableSet<String> = mutableSetOf(Union::class.java.name)
 
-    override fun process(annotations: MutableSet<out TypeElement>?, roundEnv: RoundEnvironment): Boolean {
+    override fun process(annotations: Set<TypeElement>, roundEnv: RoundEnvironment): Boolean {
         val annotatedElements = roundEnv.getElementsAnnotatedWith(Union::class.java)
         if (annotatedElements.isEmpty()) return false
-
-        val path = processingEnv.options[KAPT_KOTLIN_GENERATED_OPTION_NAME] ?: run {
-            processingEnv.messager.printMessage(ERROR, "Can't find the target directory for generated Kotlin files.")
+        val environment = (this as KotlinAbstractProcessor).processingEnv
+        val path = environment.options[KAPT_KOTLIN_GENERATED_OPTION_NAME] ?: run {
+            environment.messager.printMessage(ERROR, "Can't find the target directory for generated Kotlin files.")
             return false
         }
 
-        val transformer = TransformUnion()
         annotatedElements
             .map { methodElement ->
                 transformer(
                     element = methodElement,
-                    packageOf = processingEnv.elementUtils.getPackageOf(methodElement).qualifiedName.toString()
+                    packageOf = environment.elementUtils.getPackageOf(methodElement).qualifiedName.toString()
                 )
             }
             .forEach { fileSpec -> writeToFile(fileSpec, path) }
+
         return true
     }
 

--- a/unikons/src/main/kotlin/com/lotuslambda/unikons/utils.kt
+++ b/unikons/src/main/kotlin/com/lotuslambda/unikons/utils.kt
@@ -1,0 +1,31 @@
+package com.lotuslambda.unikons
+
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.asTypeName
+import me.eugeniomarletti.kotlin.metadata.shadow.name.FqName
+import me.eugeniomarletti.kotlin.metadata.shadow.platform.JavaToKotlinClassMap
+import javax.lang.model.type.TypeMirror
+
+fun TypeMirror.toKotlinClassName(): ClassName {
+    var currentClass = ClassName.bestGuess(asTypeName().toString())
+    val typeName = asTypeName().toString()
+
+    //Simple check to see if we're using a Java type instead of a Kotlin one
+    if (currentClass.packageName.isFromJava() && typeName.isFromJava()) {
+        val kotlinVersion = JavaToKotlinClassMap
+            .mapJavaToKotlin(FqName(currentClass.canonicalName))
+
+        if (kotlinVersion != null) {
+            currentClass = ClassName(
+                kotlinVersion.packageFqName.asString(),
+                kotlinVersion.asSingleFqName().shortName().asString()
+            )
+        }
+    }
+
+    return currentClass
+}
+
+private fun String.isFromJava(): Boolean {
+    return startsWith("java.lang")
+}


### PR DESCRIPTION
This patch adds a dependency on kotlin metadata library,
allowing extra metadata to be kept and usage of basic kotlin
types instead of replacing them with Java types.

This also closes issue #2  🎉  
